### PR TITLE
因s*s升级至3.1.7，dnsmasq配置文件路径对应修改

### DIFF
--- a/iptv-71.sh
+++ b/iptv-71.sh
@@ -42,7 +42,7 @@ echo
 #脚本提示
 echo 正在修改ss dnsmasq配置文件
 #移动到ss dnsmasq目录
-cd /koolshare/ss/redchn
+cd /koolshare/ss/rules
 #删除旧配置文件
 echo 正在删除旧文件
 rm -rf dnsmasq.postconf


### PR DESCRIPTION
原路径为/koolshare/ss/redchn
修改后的路径应为/koolshare/ss/rules